### PR TITLE
Add support for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The language that is interpreted is called AHA, it's syntax is block based denot
 - Looping (for loop)
 - Conditional operators (<,>,>=,<=)
 - Lists and basic operations (pop, append, remove and add)
+- Comments
 
 ## Examples
 
@@ -87,17 +88,28 @@ print 5 <= 6
 ```
 x = [1, 2, 3]
 y = x[1]
-print y
+print y 
 
-print x
-x = x << "hellows world"
-print x
+print x 
+x = x << "hellows world" # appends value to the end of list
+print x 
 
-x = x >> 0
-z = x =>> 0
-print x
+x = x >> 0 # Deletes the item at position 0 from the list
+z = x =>> 0 # Pops the item at position 0, returning the element
+print x 
 print z
 
-x = x << 1 <<= 5
+x = x << 1 <<= 5 # Add 5 to the list, placing it a the index 1 position 
 print x
+```
+
+### Comments
+```
+# This is a comment
+
+/*
+    This is a
+    multiline
+    comment :)
+*/
 ```

--- a/example/comments.aha
+++ b/example/comments.aha
@@ -1,0 +1,7 @@
+# This is a comment
+
+/*
+    This is a
+    multiline
+    comment :)
+*/

--- a/example/lists.aha
+++ b/example/lists.aha
@@ -1,15 +1,15 @@
 x = [1, 2, 3]
 y = x[1]
-print y
+print y 
 
-print x
-x = x << "hellows world"
-print x
+print x 
+x = x << "hellows world" # appends value to the end of list
+print x 
 
-x = x >> 0
-z = x =>> 0
-print x
+x = x >> 0 # Deletes the item at position 0 from the list
+z = x =>> 0 # Pops the item at position 0, returning the element
+print x 
 print z
 
-x = x << 1 <<= 5
+x = x << 1 <<= 5 # Add 5 to the list, placing it a the index 1 position 
 print x

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -199,6 +199,10 @@ eval (ListAdd listExpr indexExpr elemExpr) = do
             else throwError "Index out of bounds"
         _ -> throwError "Type mismatch in list add"
 
+eval (Comment _) = return NullVal
+
+eval (MultiLineComment _) = return NullVal
+
 getListName :: Expr -> String
 getListName (Var name) = name
 getListName _ = error "Expected a variable name for list"


### PR DESCRIPTION
Introduces support for single-line and multi-line comments in the AHA language. 

### Documentation and Examples:

* Added a section on comments in `README.md` to explain the syntax for single-line and multi-line comments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-R115)
* Updated `example/comments.aha` and `example/lists.aha` to include examples of comments. [[1]](diffhunk://#diff-11006f0b3563b654ce9d6bbd06212fd31d6879c4de5eec5ffaeca2f24ee52e09R1-R7) [[2]](diffhunk://#diff-c4a9b5df3ff33f923a1b899a7ddf093e2dcf0b6df59b5c1442a46b7897e43985L6-R14)

### Interpreter Changes:

* Modified `src/Interpreter.hs` to handle `Comment` and `MultiLineComment` expressions by returning `NullVal`.

### Parser Changes:

* Updated `src/SimpleParser.hs` to include `Comment` and `MultiLineComment` in the `Expr` data type and added parsing logic for these comment types. [[1]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R33-R34) [[2]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R70-R83) [[3]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R160-R161)

### Test Updates:

* Added tests in `test/Spec.hs` to verify parsing and ignoring of single-line and multi-line comments. [[1]](diffhunk://#diff-04af28cae6432907ee5f5cae0418fb0faa8854ce1a13e5e86e6f9d6cd3fe5154R78-R93) [[2]](diffhunk://#diff-04af28cae6432907ee5f5cae0418fb0faa8854ce1a13e5e86e6f9d6cd3fe5154R419-R429)