### PR TITLE
Added support for logical operators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The language that is interpreted is called AHA, it's syntax is block based denot
 - Lists and basic operations (pop, append, remove and add)
 - Comments
 - Function definitions
+- Basic logical operation
 
 ## Examples
 
@@ -130,4 +131,17 @@ z = add(x, y)
 
 sayHello()
 print z
+```
+
+### Logical operations
+```
+print true and false
+print true and true
+
+print true or true
+print false or false
+print false or true
+
+print not false
+print not true
 ```

--- a/example/logical-ops.aha
+++ b/example/logical-ops.aha
@@ -1,0 +1,9 @@
+print true and false
+print true and true
+
+print true or true
+print false or false
+print false or true
+
+print not false
+print not true

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -228,7 +228,7 @@ eval (FuncCall name args) = do
 
 eval (Return exprs) = eval exprs
 
-eval (And v1 v2) = do
+eval (LogicAnd v1 v2) = do
     val1 <- eval v1
     val2 <- eval v2
     case (val1, val2) of
@@ -237,7 +237,7 @@ eval (And v1 v2) = do
         (BoolVal b1, BoolVal b2) -> return $ BoolVal (b1 && b2)
         _ -> throwError "Type mismatch in and"
 
-eval (Or v1 v2) = do
+eval (LogicOr v1 v2) = do
     val1 <- eval v1
     val2 <- eval v2
     case (val1, val2) of
@@ -246,7 +246,7 @@ eval (Or v1 v2) = do
         (BoolVal b1, BoolVal b2) -> return $ BoolVal (b1 || b2)
         _ -> throwError "Type mismatch in or"
 
-eval (Not v) = do
+eval (LogicNot v) = do
     val <- eval v
     case val of
         StrVal s -> return $ BoolVal (s == "")

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -226,8 +226,34 @@ eval (FuncCall name args) = do
         put oldEnv
         return result
 
-
 eval (Return exprs) = eval exprs
+
+eval (And v1 v2) = do
+    val1 <- eval v1
+    val2 <- eval v2
+    case (val1, val2) of
+        (StrVal s1, StrVal s2) -> return $ BoolVal (s1 /= "" && s2 /= "")
+        (IntVal n1, IntVal n2) -> return $ BoolVal (n1 /= 0 && n2 /= 0)
+        (BoolVal b1, BoolVal b2) -> return $ BoolVal (b1 && b2)
+        _ -> throwError "Type mismatch in and"
+
+eval (Or v1 v2) = do
+    val1 <- eval v1
+    val2 <- eval v2
+    case (val1, val2) of
+        (StrVal s1, StrVal s2) -> return $ BoolVal (s1 /= "" || s2 /= "")
+        (IntVal n1, IntVal n2) -> return $ BoolVal (n1 /= 0 || n2 /= 0)
+        (BoolVal b1, BoolVal b2) -> return $ BoolVal (b1 || b2)
+        _ -> throwError "Type mismatch in or"
+
+eval (Not v) = do
+    val <- eval v
+    case val of
+        StrVal s -> return $ BoolVal (s == "")
+        IntVal n -> return $ BoolVal (n == 0)
+        BoolVal b -> return $ BoolVal (not b)
+        _ -> throwError "Type mismatch in not"
+
 
 
 getListName :: Expr -> String

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,2 @@
 resolver: lts-22.35
+notify-if-nix-on-path: false


### PR DESCRIPTION
Added support for logical `and`, `or`, and `not` operations, updating the parser to handle these new logical operations.

### Logical Operations Implementation:

* [`src/Interpreter.hs`](diffhunk://#diff-b92083a5ecba1c075ca8bddafddf4ef70743dff49cfe4de61e72c5f5052c269dL229-R257): Added evaluation logic for `LogicAnd`, `LogicOr`, and `LogicNot` expressions.
* [`src/SimpleParser.hs`](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R26-R28): Updated the parser to recognize and parse logical operations (`and`, `or`, `not`). [[1]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R26-R28) [[2]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R154) [[3]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R168-R172)

### General changes
* `stack.yaml`: Added the `notify-if-nix-on-path` configuration to remove warning that was given if nix is installed on the system for development. 

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18): Added a new section to document the syntax and usage of logical operations in AHA. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R147)

### Example Code:

* [`example/logical-ops.aha`](diffhunk://#diff-c4a681d6e0840a08bcc9bfb6f8eeadfdad75ea9df3ea67e4587325e47c2b24daR1-R9): Added example code demonstrating the use of logical operations.

### Test Suite Enhancements:

* [`test/Spec.hs`](diffhunk://#diff-04af28cae6432907ee5f5cae0418fb0faa8854ce1a13e5e86e6f9d6cd3fe5154R110-R117): Added multiple test cases to ensure correct parsing and evaluation of logical operations, including edge cases and type mismatches. [[1]](diffhunk://#diff-04af28cae6432907ee5f5cae0418fb0faa8854ce1a13e5e86e6f9d6cd3fe5154R110-R117) [[2]](diffhunk://#diff-04af28cae6432907ee5f5cae0418fb0faa8854ce1a13e5e86e6f9d6cd3fe5154R471-R542)