### PR TITLE
Add support for next and haltLoop statements in loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The language that is interpreted is called AHA, it's syntax is block based denot
 - Function definitions
 - Basic logical operation
 - Basic module handling
+- Loop flow control (haltLoop, next, next if, next unless)
 
 ## Examples
 
@@ -169,4 +170,28 @@ loop (y < 5) {
     print y
     y = y + 1
 } 
+```
+
+### Loop flow control
+
+```
+loop (true) {
+    print "once"
+    haltLoop
+}
+
+for (i = 0; i < 5; i = i + 1) {
+    next if i < 4
+    print i
+}
+
+for (i = 0; i < 5; i = i + 1) {
+    next unless i < 3
+    print i
+}
+
+for (i = 0; i < 5; i = i + 1) {
+    next
+    print i
+}
 ```

--- a/example/flowControl.aha
+++ b/example/flowControl.aha
@@ -1,0 +1,19 @@
+loop (true) {
+    print "once"
+    haltLoop
+}
+
+for (i = 0; i < 5; i = i + 1) {
+    next if i < 4
+    print i
+}
+
+for (i = 0; i < 5; i = i + 1) {
+    next unless i < 3
+    print i
+}
+
+for (i = 0; i < 5; i = i + 1) {
+    next
+    print i
+}

--- a/test/InterpreterSpec.hs
+++ b/test/InterpreterSpec.hs
@@ -405,6 +405,24 @@ spec = context "Interpreter" $ do
           result <- runInterpreter Map.empty exprs
           result `shouldBe` Right (IntVal 0, Map.fromList [("add", FuncVal ["x", "y"] [Return (Add (Var "x") (Var "y"))] Map.empty), ("z", IntVal 3)])
 
+    describe "Loop controls" $ do
+        describe "haltLoop statement" $ do
+            it "should evaluate a haltLoop statement" $ do
+                let exprs = [WhileLoop (BoolLit True) [Assign "x" (IntLit 1), Break, Assign "y" (IntLit 2)]]
+                result <- runInterpreter Map.empty exprs
+                result `shouldBe` Right (IntVal 0, Map.fromList [("x", IntVal 1)])
+            
+            it "should evaluate a haltLoop statement inside a nested loop" $ do
+                let exprs = [WhileLoop (BoolLit True) [Assign "x" (IntLit 1), WhileLoop (BoolLit True) [Assign "y" (IntLit 2), Break, Assign "z" (IntLit 3)], Break, Assign "w" (IntLit 4)]]
+                result <- runInterpreter Map.empty exprs
+                result `shouldBe` Right (IntVal 0, Map.fromList [("x", IntVal 1), ("y", IntVal 2)])
+
+        describe "next statements" $ do
+            it "should evaluate a next statement" $ do
+                let exprs = [Assign "x" (IntLit 0), WhileLoop (Lt (Var "x") (IntLit 5)) [Assign "x" (Add (Var "x") (IntLit 1)), Next]]
+                result <- runInterpreter Map.empty exprs
+                result `shouldBe` Right (IntVal 0, Map.fromList [("x", IntVal 5)])
+            
     describe "Logical operations" $ do
       it "should evaluate logical and operator (and)" $ do
           let exprs = [Assign "x" (LogicAnd (BoolLit True) (BoolLit False))]

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -90,6 +90,31 @@ spec = context "SimpleParser" $ do
       it "should correctly parse inline comments on the side of a statement" $ do
         parseProgram "x = 42 # This is a comment" `shouldBe` Right [Assign "x" (IntLit 42)]
 
+    describe "Loop controls" $ do
+      it "should parse next statement inside a loop" $ do
+        parseProgram "loop (true) { next }" `shouldBe` Right [WhileLoop (BoolLit True) [Next]]
+
+      it "should parse next if statement inside a loop" $ do
+        parseProgram "loop (true) { next if true }" `shouldBe` Right [WhileLoop (BoolLit True) [If (BoolLit True) [Next] []]]
+
+      it "should parse next unless statement inside a loop" $ do
+        parseProgram "loop (true) { next unless true }" `shouldBe` Right [WhileLoop (BoolLit True) [If (BoolLit True) [] [Next]]]
+
+      it "should parse haltLoop statement inside a loop" $ do
+        parseProgram "loop (true) { haltLoop }" `shouldBe` Right [WhileLoop (BoolLit True) [Break]]
+
+      it "should throw an error if next statement is used outside a loop" $ do
+        parseProgram "next" `shouldSatisfy` isLeft
+
+      it "should throw an error if next if statement is used outside a loop" $ do
+        parseProgram "next if true" `shouldSatisfy` isLeft
+      
+      it "should throw an error if next unless statement is used outside a loop" $ do
+        parseProgram "next unless true" `shouldSatisfy` isLeft
+
+      it "should throw an error if haltLoop statement is used outside a loop" $ do
+        parseProgram "haltLoop" `shouldSatisfy` isLeft
+
     describe "Function definition" $ do
       it "should parse a function definition" $ do
         parseProgram "def add(x, y) { return x + y }" `shouldBe` Right [FuncDef "add" ["x", "y"] [Return (Add (Var "x") (Var "y"))]]


### PR DESCRIPTION
This pull request introduces loop control flow enhancements to the AHA language, including new syntax and interpreter support for `haltLoop`, `next`, `next if`, and `next unless` statements. 

### Loop Control Flow Enhancements:

* **Documentation Updates:**
  * Added loop flow control descriptions to the `README.md` file, including examples of `haltLoop`, `next`, `next if`, and `next unless` usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R174-R197)

* **Interpreter Enhancements:**
  * Added `NextVal` and `BreakVal` to the `Value` data type to represent loop control values.
  * Implemented `eval` functions for `Break` and `Next` expressions.
  * Modified `evalWhile` and `evalForLoop` functions to handle `BreakVal` and `NextVal` appropriately, ensuring correct loop control behavior. [[1]](diffhunk://#diff-b92083a5ecba1c075ca8bddafddf4ef70743dff49cfe4de61e72c5f5052c269dL331-L340) [[2]](diffhunk://#diff-b92083a5ecba1c075ca8bddafddf4ef70743dff49cfe4de61e72c5f5052c269dL349-R384)
  * Introduced `evalBlockWithControl` to manage expressions with control flow within loops.

* **Parser Enhancements:**
  * Added `Next` and `Break` expressions to the `Expr` data type.
  * Updated loop parsers to handle new loop control statements. [[1]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254L468-R472) [[2]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254L486-R490) [[3]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254L501-R568)
  * Implemented parsers for `next`, `next if`, `next unless`, and `haltLoop` statements.

* **Example and Test Updates:**
  * Added an example file demonstrating loop control statements (`example/flowControl.aha`).
  * Updated `InterpreterSpec.hs` with tests for `haltLoop` and `next` statements within loops.
  * Updated `ParserSpec.hs` with tests for parsing loop control statements and ensuring errors when used outside loops.