### PR TITLE
Add range support, including stepping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The language that is interpreted is called AHA, it's syntax is block based denot
 - Basic logical operation
 - Basic module handling
 - Loop flow control (haltLoop, next, next if, next unless)
+- Ranges
 
 ## Examples
 
@@ -105,6 +106,12 @@ print z
 
 x = x << 1 <<= 5 # Add 5 to the list, placing it a the index 1 position 
 print x
+
+w = 1..10 
+print w
+
+w = 1..10 stepping 2
+print w
 ```
 
 ### Comments

--- a/example/lists.aha
+++ b/example/lists.aha
@@ -13,3 +13,9 @@ print z
 
 x = x << 1 <<= 5 # Add 5 to the list, placing it a the index 1 position 
 print x
+
+w = 1..10 
+print w
+
+w = 1..10 stepping 2
+print w

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -318,6 +318,17 @@ eval Break = return BreakVal
 
 eval Next = return NextVal
 
+eval (ListRange start end optionalStep) = do
+    startVal <- eval start
+    endVal <- eval end
+    stepVal <- case optionalStep of
+        Just step -> eval step
+        Nothing -> return $ IntVal 1
+
+    case (startVal, endVal, stepVal) of
+        (IntVal s, IntVal e, IntVal st) -> return $ ListVal [IntVal x | x <- [s, s + st .. e]]
+        _ -> throwError "Type mismatch in list range"
+
 
 -- | The 'getListName' function returns the name of the list if is a variable.
 getListName :: Expr -> String

--- a/src/SimpleParser.hs
+++ b/src/SimpleParser.hs
@@ -80,7 +80,9 @@ data Expr
     | Next 
     -- ^ Represents the next statement in the AHA language.   
     | Break
-    -- ^ Represents the break statement in the AHA language.        
+    -- ^ Represents the break statement in the AHA language.   
+    | ListRange Expr Expr (Maybe Expr)
+    -- ^ Represents a range of elements in a list. The first Expr is the start index, the second is the end index, the third is the step.     
     deriving (Show, Eq)
 
 {-
@@ -308,6 +310,16 @@ listAdd = do
 
     return $ ListAdd list index element
 
+
+rangeStatement :: Parser Expr
+rangeStatement = do
+    start <- term
+    _ <- symbol ".."
+    end <- term
+    step <- optional $ do
+        _ <- symbol "stepping"
+        term
+    return $ ListRange start end step
 
 {-
     ######################################
@@ -599,6 +611,7 @@ Parses an expression from the input. The parser consumes a term followed by an o
 -}
 expr :: Parser Expr
 expr = try functionCall
+    <|> try rangeStatement
     <|> try listAdd
     <|> try listAppend
     <|> try listRemove
@@ -645,6 +658,7 @@ statement = try assignment
         <|> try whileLoop
         <|> try importModule
         <|> try functionCall
+        <|> try rangeStatement
         <|> try doWhileLoop
         <|> try forStatement
         <|> try ifStatement

--- a/test/InterpreterSpec.hs
+++ b/test/InterpreterSpec.hs
@@ -422,7 +422,24 @@ spec = context "Interpreter" $ do
                 let exprs = [Assign "x" (IntLit 0), WhileLoop (Lt (Var "x") (IntLit 5)) [Assign "x" (Add (Var "x") (IntLit 1)), Next]]
                 result <- runInterpreter Map.empty exprs
                 result `shouldBe` Right (IntVal 0, Map.fromList [("x", IntVal 5)])
-            
+
+    describe "Range" $ do
+        it "should evaluate a range statement with a default step of 1" $ do
+            let exprs = [Assign "x" (ListRange (IntLit 1) (IntLit 5) Nothing)]
+            result <- runInterpreter Map.empty exprs
+            result `shouldBe` Right (IntVal 0, Map.fromList [("x", ListVal [IntVal 1, IntVal 2, IntVal 3, IntVal 4, IntVal 5])])
+
+        it "should evaluate a range statement with a step of 2" $ do
+            let exprs = [Assign "x" (ListRange (IntLit 1) (IntLit 5) (Just (IntLit 2)))]
+            result <- runInterpreter Map.empty exprs
+            result `shouldBe` Right (IntVal 0, Map.fromList [("x", ListVal [IntVal 1, IntVal 3, IntVal 5])])
+
+        it "should evaluate a range statement with a negative step" $ do
+            let exprs = [Assign "x" (ListRange (IntLit 5) (IntLit 1) (Just (IntLit (-1))))]
+            result <- runInterpreter Map.empty exprs
+            result `shouldBe` Right (IntVal 0, Map.fromList [("x", ListVal [IntVal 5, IntVal 4, IntVal 3, IntVal 2, IntVal 1])])
+
+
     describe "Logical operations" $ do
       it "should evaluate logical and operator (and)" $ do
           let exprs = [Assign "x" (LogicAnd (BoolLit True) (BoolLit False))]

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -74,6 +74,12 @@ spec = context "SimpleParser" $ do
       it "should parse list add" $ do
         parseProgram "x = [1, 2, 3] << 0 <<= 4" `shouldBe` Right [Assign "x" (ListAdd (ListLit [IntLit 1, IntLit 2, IntLit 3]) (IntLit 0) (IntLit 4))]
 
+    describe "Range" $ do
+      it "should parse range" $ do
+        parseProgram "x = 1..10" `shouldBe` Right [Assign "x" (ListRange (IntLit 1) (IntLit 10) (Nothing))]
+      it "should parse range with step" $ do
+        parseProgram "x = 1..10 stepping 2" `shouldBe` Right [Assign "x" (ListRange (IntLit 1) (IntLit 10) (Just (IntLit 2)))]
+
     describe "Comments" $ do
       it "should parse single line comment" $ do
         parseProgram "# This is a comment" `shouldBe` Right []


### PR DESCRIPTION
Support range expressions in the AHA language.

### Documentation Updates:
* Added information about ranges in the `README.md` file, including examples of range usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R114)

### Parser Enhancements:
* Added a `ListRange` constructor to the `Expr` data type in `src/SimpleParser.hs` to represent range expressions.
* Implemented a new parser function `rangeStatement` to parse range expressions, and integrated it into the `expr` and `statement` parsing functions. [[1]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R314-R323) [[2]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R614) [[3]](diffhunk://#diff-e8c553f13506bb6a95e3fa1df4470b4556b100037cb73733b666d26806a80254R661)

### Interpreter Enhancements:
* Updated `src/Interpreter.hs` to evaluate `ListRange` expressions, handling both default and specified step values.

### Test Coverage:
* Added tests in `test/InterpreterSpec.hs` to verify the correct evaluation of range expressions with different step values.
* Added tests in `test/ParserSpec.hs` to ensure the parser correctly handles range expressions and range expressions with steps.

### Example Updates:
* Updated `example/lists.aha` to include examples demonstrating the use of range expressions.